### PR TITLE
Fix Issue #7 - InstallDriver Not Throwing Error on Missing -Name

### DIFF
--- a/InvocationContexts/DriverInvocation.cs
+++ b/InvocationContexts/DriverInvocation.cs
@@ -75,7 +75,10 @@ namespace Printune
                 _path = Environment.CurrentDirectory;
             }
 
-            ParameterParser.GetParameterValue(Args, "-Name", out _name);
+            if (!ParameterParser.GetParameterValue(Args, "-Name", out _name) && _intent == "installation")
+            {
+                throw new Invocation.InvalidNameOrPathException("No driver name provided for installation.");
+            }
 
             if (!File.Exists(_path) && !Directory.Exists(_path))
             {
@@ -121,7 +124,7 @@ namespace Printune
                     try
                     {
                         if (!String.IsNullOrEmpty(_name))
-                        driverEnabled |= PrinterDriver.EnablePrinterDriver(_name) != null;
+                            driverEnabled |= PrinterDriver.EnablePrinterDriver(_name) != null;
                     }
                     catch
                     {

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Printune can
 Both network printers and drivers.
 
 ## Syntax
-    printune.exe InstallDriver [-Recurse] {-Path <driver.inf> | -Path <folder\> } [-LogPath <file.log>]
+    printune.exe InstallDriver [-Recurse] {-Path <driver.inf> | -Path <folder\> } { -Name <driver name> } [-LogPath <file.log>]
     printune.exe UninstallDriver { -Driver <PrinterDriverName> | -Path <driver.inf> } [-LogPath <file.log>]
     
     printune.exe InstallPrinter { -Name <PrinterName> } [ -Config <config.json> ] [-LogPath <file.log>]
@@ -101,11 +101,11 @@ You can even specify a file that's accessible over HTTP/S.
 ## Drivers
 Printune can install and uninstall drivers with just a few arguments.
 ### Installing a Driver with a Single .inf File
-    C:\> printune.exe InstallDriver -Path zerocks_uni_pcl6\x3UNIVZ.inf
+    C:\> printune.exe InstallDriver -Path zerocks_uni_pcl6\x3UNIVZ.inf -Name "Zerocks Global PCL6"
 ### Installing a Driver with Many .inf Files
-    C:\> printune.exe InstallDriver -Recurse -Path driver\
+    C:\> printune.exe InstallDriver -Recurse -Path "driver\" -Name "Zerocks Global PCL6"
 ### Uninstalling a Driver Using an .inf File Path
-    C:\> printune.exe UninstallDriver -Path zerocks_uni_pcl6\x3UNIVZ.inf
+    C:\> printune.exe UninstallDriver -Path "zerocks_uni_pcl6\x3UNIVZ.inf"
 ### Uninstalling a Driver by Name
     C:\> printune.exe UninstallDriver -Driver "Zerocks Global PCL6"
 


### PR DESCRIPTION
Fixed issue where InstallDriver intent does not throw an error when driver name param is missing and updated documentation to indicate that parameter is required.