### PR TITLE
Added Printer Preferences Export and Restore

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,7 +31,7 @@
             "cwd": "${workspaceFolder}",
             "program": "${workspaceFolder}/bin/Debug/net8.0/win-x64/Printune.dll",
             "args" : [
-                "InstallPrinter", "-PrinterName", "CanonPrintune", "-Config", "C:\\temp\\B38U\\config.json"
+                "InstallPrinter", "-PrinterName", "B38U", "-Config", "C:\\temp\\B38U\\config.json"
             ],
             "console": "internalConsole",
             "env": {
@@ -68,7 +68,7 @@
             "cwd": "${workspaceFolder}",
             "program": "${workspaceFolder}/bin/Debug/net8.0/win-x64/Printune.dll",
             "args" : [
-                "PackagePrinter", "-PrinterName", "ZDesigner GK420t", "-Output", "C:\\Temp\\Zebra", "-IntuneWinUtil", "C:\\Tools\\IntuneWinAppUtil.exe"
+                "PackagePrinter", "-PrinterName", "B38U", "-ExportPreferences", "-Output", "C:\\Temp\\B38U", "-IntuneWinUtil", "C:\\Tools\\IntuneWinAppUtil.exe"
             ],
             "console": "internalConsole",
             "env": {

--- a/InvocationContexts/PrinterInvocation.cs
+++ b/InvocationContexts/PrinterInvocation.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Printune.Models;
 
 namespace Printune
 {
@@ -88,6 +89,9 @@ namespace Printune
                 // Creates Windows the print queue.
                 printer.Commit();
                 Log.Write($"Printer successfully added.");
+
+                if (!String.IsNullOrEmpty(printer.PreferenceFile))
+                    new PrinterPreference(printer.PreferenceFile).Apply(_printerName);
             }
             else
             {

--- a/Models/Printer.cs
+++ b/Models/Printer.cs
@@ -20,6 +20,9 @@ namespace Printune
         public string DriverName { get; set; } = string.Empty;
         public string DataType { get; set; } = string.Empty;
         public string PrintProcessor { get; set; } = string.Empty;
+        [JsonProperty(Required = Required.Default)]
+        public string PreferenceFile { get; set; } = null;
+
         [JsonIgnore]
         public string PortName
         {
@@ -299,9 +302,12 @@ namespace Printune
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
-        public static string SerializeExisting(string PrinterName)
+        public static string SerializeExisting(string PrinterName, string PreferenceFile = null)
         {
             var printer = FromExisting(PrinterName);
+            if (!string.IsNullOrEmpty(PreferenceFile))
+                printer.PreferenceFile = PreferenceFile;
+            
             if (printer == null)
                 return null;
             else

--- a/Models/PrinterPreference.cs
+++ b/Models/PrinterPreference.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Printune.Models
+{
+    public class PrinterPreference
+    {
+        public string PreferenceFile { get; private set; }
+
+        public PrinterPreference(string preferenceFile)
+        {
+            PreferenceFile = ConfigReader.CopyToLocal(preferenceFile);
+            if (!File.Exists(PreferenceFile))
+                if (preferenceFile.StartsWith(Path.GetTempPath(), StringComparison.InvariantCultureIgnoreCase))
+                    throw new FileNotFoundException("The specified printer preference file failed to copy to a local temporary file but did not throw an error.", preferenceFile);
+                else
+                    throw new FileNotFoundException("The specified printer preference file does not exist.", PreferenceFile);
+        }
+
+        public void Apply(string PrinterName)
+        {
+            if (!Invocation.IsElevated)
+                throw new UnauthorizedAccessException("Applying printer preferences requires elevated (administrator) permissions.");
+
+            using (var printer = Printer.FromExisting(PrinterName))
+            {
+                if (printer == null)
+                    throw new ArgumentException($"The specified printer '{PrinterName}' does not exist.", nameof(PrinterName));
+
+                PrintUIApply(PrinterName);
+            }
+        }
+
+        private void PrintUIApply(string PrinterName)
+        {
+            var psi = new ProcessStartInfo()
+            {
+                FileName = "rundll32.exe",
+                Arguments = $"printui.dll,PrintUIEntry /Ss /n \"{PrinterName}\" /a \"{PreferenceFile}\" /q",
+                WindowStyle = ProcessWindowStyle.Hidden,
+                WorkingDirectory = Directory.GetCurrentDirectory()
+            };
+
+            using (var proc = Process.Start(psi))
+            {
+                if (proc == null)
+                    throw new InvalidOperationException("Failed to start the PrintUI process to apply printer preferences.");
+
+                proc.WaitForExit();
+                if (proc.ExitCode != 0)
+                    throw new InvalidOperationException($"The PrintUI process to apply printer preferences exited with an error. Exit code: {proc.ExitCode}");
+
+                Log.Write("Printing prefrences applied successfully.");
+            }
+        }
+        public static void Export(string PrinterName, string OutputFile)
+        {
+            bool debug = false;
+            #if DEBUG
+            debug = true;
+            #endif
+            if (!Invocation.IsElevated && !debug)
+                throw new UnauthorizedAccessException("Applying printer preferences requires elevated (administrator) permissions.");
+
+            using (var printer = Printer.FromExisting(PrinterName))
+            {
+                if (printer == null)
+                    throw new ArgumentException($"The specified printer '{PrinterName}' does not exist.", nameof(PrinterName));
+
+                PrintUIExport(PrinterName, OutputFile);
+            }
+        }
+
+        private static void PrintUIExport(string PrinterName, string OutputFile)
+        {
+            var psi = new ProcessStartInfo()
+            {
+                FileName = "rundll32.exe",
+                Arguments = $"printui.dll,PrintUIEntry /Sr /n \"{PrinterName}\" /a \"{OutputFile}\" /q",
+                WindowStyle = ProcessWindowStyle.Hidden,
+                WorkingDirectory = Directory.GetCurrentDirectory()
+            };
+
+            using (var proc = Process.Start(psi))
+            {
+                if (proc == null)
+                    throw new InvalidOperationException("Failed to start the PrintUI process to export printer preferences.");
+
+                proc.WaitForExit();
+                if (proc.ExitCode != 0)
+                    Log.Write($"The PrintUI process to export printer preferences exited with an error. Exit code: {proc.ExitCode}", true);
+
+                Log.Write($"Printing prefrences exported successfully to {OutputFile}");
+            }
+        }
+    }
+}

--- a/Utils/ConfigReader.cs
+++ b/Utils/ConfigReader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 
 namespace Printune
@@ -23,8 +24,44 @@ namespace Printune
                     throw new Invocation.InvalidNameOrPathException("Invalid invocation: The provided configuration file path is not a valid HTTP, HTTPS, or file path.");
             }
         }
+        public static byte[] ReadAsBytes(string ConfigPath)
+        {
+            ConfigPath = ExpandIfRelative(ConfigPath);
 
-        private static string ExpandIfRelative(string ConfigPath)
+            var configUri = new Uri(ConfigPath);
+            // Allow filesystem paths as well because they could be
+            // be on shared drives with UNC paths.
+            switch (configUri.Scheme)
+            {
+                case "http":
+                    return ReadHttpAsBytes(configUri);
+                case "https":
+                    return ReadHttpAsBytes(configUri);
+                case "file":
+                    return ReadFileAsBytes(configUri);
+                default:
+                    throw new Invocation.InvalidNameOrPathException("Invalid invocation: The provided configuration file path is not a valid HTTP, HTTPS, or file path.");
+            }
+        }
+        /// <summary>
+        /// Copies the configuration file to a local temporary file and returns the local file path.
+        /// If it is already a local file, the original file path is returned, but fully qualified.
+        /// </summary>
+        /// <param name="ConfigPath"></param>
+        /// <returns>Fully qualified local file path.</returns>
+        public static string CopyToLocal(string ConfigPath)
+        {
+            ConfigPath = ExpandIfRelative(ConfigPath);
+            var configUri = new Uri(ConfigPath);
+
+            if (configUri.IsFile && !configUri.IsUnc)
+                return configUri.LocalPath;
+
+            var filePath = Path.GetTempFileName();
+            File.WriteAllBytes(filePath, ReadAsBytes(ConfigPath));
+            return filePath;
+        }
+        public static string ExpandIfRelative(string ConfigPath)
         {
             if (File.Exists(ConfigPath))
                 return Path.GetFullPath(ConfigPath);
@@ -38,23 +75,28 @@ namespace Printune
         }
         private static string ReadHttp(Uri ConfigPath)
         {
+            var bytes = ReadHttpAsBytes(ConfigPath);
+            return System.Text.Encoding.UTF8.GetString(bytes);
+        }
+        private static byte[] ReadHttpAsBytes(Uri ConfigPath)
+        {
             using (var client = new HttpClient())
             {
                 var response = client.GetAsync(ConfigPath).Result;
 
                 if (response.IsSuccessStatusCode)
                 {
-                    return response.Content.ReadAsStringAsync().Result;
+                    return response.Content.ReadAsByteArrayAsync().Result;
                 }
                 else
                 {
-                    if (response.Content == null)
-                        throw new HttpRequestException($"HTTP request of \"{ConfigPath.OriginalString}\" failed with HTTP status code {response.StatusCode}.");
-                    else
-                        throw new HttpRequestException($"HTTP request of \"{ConfigPath.OriginalString}\" failed with HTTP status code {response.StatusCode}"
-                                                        + $" and reponse of \n \"{response.Content.ReadAsStringAsync()}\"");
+                    throw new HttpRequestException($"HTTP request of \"{ConfigPath.OriginalString}\" failed with HTTP status code {response.StatusCode}.");
                 }
             }
+        }
+        private static byte[] ReadFileAsBytes(Uri ConfigPath)
+        {
+            return File.ReadAllBytes(ConfigPath.OriginalString);
         }
     }
 }


### PR DESCRIPTION
Printer preferences can now be exported with the `PackagePrinter` intent's `-ExportPreferences` command flag, which adds the `PreferenceFile` value to the configuration JSON file for use when installing the printer.

Both exporting and restoring the preferences require administrative privileges.