### PR TITLE
Driver Detection Script Problem Fixed

### DIFF
--- a/InvocationContexts/IntunePackageInvocation.cs
+++ b/InvocationContexts/IntunePackageInvocation.cs
@@ -404,7 +404,7 @@ $dn = ""${driverName}""; $dv = ""${driverVersion}""
 try {
     $iv = (Get-WindowsDriver -Online -Driver (Get-PrinterDriver $dn).InfPath)[0].Version
     if (([string]::IsNullOrWhiteSpace($dv)) -or ($dv -eq $iv))
-    { Write-Error ""Printer driver `""$dn`""$(if ($dv){"" ($dv)""} else {[string]::Empty}) installed successfully.""; exit 0 }
+    { Write-Host ""Printer driver `""$dn`""$(if ($dv){"" ($dv)""} else {[string]::Empty}) installed successfully.""; exit 0 }
     throw
 }
 catch { Write-Error ""Printer driver `""$dn`""$(if ($dv){"" ($dv)""} else {[string]::Empty}) installation failed.""; exit 1 }";


### PR DESCRIPTION
The generated driver detection script was mistakenly writing to stderr instead of stdout, which didn't fulfill the successful detection output criteria for Intune win32 app detection scripts.